### PR TITLE
Add API to get an icon from the value of 'filetype'

### DIFF
--- a/autoload/nerdfont/filetype.vim
+++ b/autoload/nerdfont/filetype.vim
@@ -1,0 +1,77 @@
+scriptencoding utf-8
+
+let g:nerdfont#filetype#customs = get(g:, 'nerdfont#filetype#customs', {})
+let g:nerdfont#filetype#defaults = {
+      \ 'awk'             : '',
+      \ 'c'               : '',
+      \ 'clojure'         : '',
+      \ 'cmake'           : '',
+      \ 'cpp'             : '',
+      \ 'cs'              : '',
+      \ 'csh'             : '',
+      \ 'css'             : '',
+      \ 'd'               : '',
+      \ 'dart'            : '',
+      \ 'diff'            : '',
+      \ 'dockerfile'      : '',
+      \ 'dosbatch'        : '',
+      \ 'dosini'          : '',
+      \ 'elm'             : '',
+      \ 'erlang'          : '',
+      \ 'euphoria3'       : '',
+      \ 'forth'           : '',
+      \ 'gitconfig'       : '',
+      \ 'go'              : '',
+      \ 'haml'            : '',
+      \ 'haskell'         : '',
+      \ 'html'            : '',
+      \ 'java'            : '',
+      \ 'javascript'      : '',
+      \ 'javascriptreact' : '',
+      \ 'json'            : '',
+      \ 'less'            : '',
+      \ 'lhaskell'        : '',
+      \ 'lua'             : '',
+      \ 'make'            : '',
+      \ 'markdown'        : '',
+      \ 'ocaml'           : 'λ',
+      \ 'pascal'          : '',
+      \ 'perl'            : '',
+      \ 'php'             : '',
+      \ 'plaintex'        : 'ﭨ',
+      \ 'postscr'         : '',
+      \ 'python'          : '',
+      \ 'r'               : 'ﳒ',
+      \ 'rmd'             : '',
+      \ 'ruby'            : '',
+      \ 'rust'            : '',
+      \ 'sass'            : '',
+      \ 'scala'           : '',
+      \ 'scss'            : '',
+      \ 'sh'              : '',
+      \ 'sql'             : '',
+      \ 'swift'           : '',
+      \ 'tads'            : '',
+      \ 'twig'            : '',
+      \ 'typescript'      : '',
+      \ 'typescriptreact' : '',
+      \ 'vim'             : '',
+      \ 'vue'             : '﵂',
+      \ 'xml'             : '',
+      \ 'yaml'            : '',
+      \ 'zsh'             : '',
+      \}
+
+function! nerdfont#filetype#find(...) abort
+  let n = a:0 ? a:1 : &filetype
+  return get(s:m, n, '')
+endfunction
+
+function! nerdfont#filetype#refresh() abort
+  let s:m = extend(
+        \ copy(g:nerdfont#filetype#defaults),
+        \ g:nerdfont#filetype#customs,
+        \)
+endfunction
+
+call nerdfont#filetype#refresh()


### PR DESCRIPTION
This is a PR for #4.

The `g:nerdfont#filetype#defaults` was made by the next script and some necessary hand-picking.
No docs and tests yet, but I'll add them before very long...


```vim
" filetype_icons.vim
" Create a dictionary that maps filetypes to icons by converting path icons.
" Place this file into the project root directory and run the next command:
" vim --clean -S filetype_icons.vim
" Then check g:filetype_icons.

set encoding=utf-8

source ./autoload/nerdfont/path/extension.vim
source ./autoload/nerdfont/path/basename.vim

let g:filetype_icons = {}


function! s:add_filetype_icon(filename, icon)
  execute 'new' fnameescape(a:filename)
  let filetype = &filetype
  quit

  if !has_key(g:filetype_icons, filetype) 
    let g:filetype_icons[filetype] = a:icon
    return
  endif

  " If the filetype is duplicate, make a list to contain all icons
  " for later hand-picking.
  if type(g:filetype_icons[filetype]) == v:t_string
    if g:filetype_icons[filetype] ==# a:icon
      return
    endif

    let g:filetype_icons[filetype] = [g:filetype_icons[filetype]]
  endif

  if index(g:filetype_icons[filetype], a:icon) < 0
    call add(g:filetype_icons[filetype], a:icon)
  endif
endfunction


for [ext, icon] in items(g:nerdfont#path#extension#defaults)
  call s:add_filetype_icon('hoge.' .. ext, icon)
endfor

for [filename, icon] in items(g:nerdfont#path#basename#defaults)
  call s:add_filetype_icon(filename, icon)
endfor
```