### PR TITLE
Add Crystal Icon

### DIFF
--- a/autoload/nerdfont/path/extension.vim
+++ b/autoload/nerdfont/path/extension.vim
@@ -20,6 +20,7 @@ let g:nerdfont#path#extension#defaults = {
       \ 'cs'       : '',
       \ 'csh'      : '',
       \ 'css'      : '',
+      \ 'cr'       : '',
       \ 'cxx'      : '',
       \ 'd'        : '',
       \ 'dart'     : '',


### PR DESCRIPTION
The icon for crystal language was added in ryanoasis/nerd-fonts#429.
Support it on this plugin.