### PR TITLE
Only apply cell widths of glyphs that are actually used

### DIFF
--- a/autoload/nerdfont.vim
+++ b/autoload/nerdfont.vim
@@ -4,6 +4,7 @@ let s:json_dir = s:path . '/assets/json'
 function! nerdfont#get_json(json_name) abort
   let l:json = s:json_dir . '/' . a:json_name . '.json'
   let l:result = json_decode(join(readfile(l:json), ''))
+  call s:autofix(l:result)
   return l:result
 endfunction
 
@@ -34,16 +35,22 @@ function! nerdfont#find(...) abort
   return g:nerdfont#default
 endfunction
 
+function! s:autofix(result) abort
+  if exists('*setcellwidths') && get(g:, 'nerdfont#autofix_cellwidths', 1)
+    try
+      let l:code_points = map(values(a:result), {_, v -> char2nr(v)})
+      let l:code_points = filter(l:code_points, {_, v -> v > 0x80})
+      call nerdfont#cellwidths#fix(l:code_points)
+    catch
+      echohl WarningMsg
+      echo '[nerdfont]: Failed to fix cellwidths of nerd font glyphs.'
+      echo '[nerdfont]: Disable this autofix feature by setting `g:nerdfont#autofix_cellwidths` to 0.'
+      echohl None
+      let g:nerdfont#autofix_cellwidths = 0
+    endtry
+  endif
+endfunction
+
 let g:nerdfont#default = get(g:, 'nerdfont#default',
       \ g:nerdfont#path#extension#defaults['.'])
 
-if exists('*setcellwidths') && get(g:, 'nerdfont#autofix_cellwidths', 1)
-  try
-    call nerdfont#cellwidths#fix()
-  catch
-    echohl WarningMsg
-    echo '[nerdfont]: Failed to fix cellwidths of nerd font glyphs.'
-    echo '[nerdfont]: Disable this autofix feature by setting `g:nerdfont#autofix_cellwidths` to 0.'
-    echohl None
-  endtry
-endif

--- a/autoload/nerdfont/cellwidths.vim
+++ b/autoload/nerdfont/cellwidths.vim
@@ -1,44 +1,5 @@
-" https://github.com/ryanoasis/nerd-fonts/wiki/Glyph-Sets-and-Code-Points#overview
-" Codicons                ea60 - ebeb
-" Devicons                e700 - e7c5
-" Font Awesome            f000 - f2e0
-" Font Awesome Extension  e200 - e2a9
-" Font Logos              f300 - f372
-" IEC Power Symbols       23fb - 23fe
-" IEC Power Symbols       2b58
-" Material Design         f0001-f1af0
-" Material Design         f500 - fd46
-" Octicons                2665
-" Octicons                26a1
-" Octicons                f400 - f532
-" Pomicons                e000 - e00a
-" Powerline               e0a0 - e0a2
-" Powerline               e0b0 - e0b3
-" Powerline Extra         e0a3
-" Powerline Extra         e0b4 - e0c8
-" Powerline Extra         e0ca
-" Powerline Extra         e0cc - e0d4
-" Seti-UI + Custom        e5fa - e6b1
-" Weather Icons           e300 - e3e3
-const g:nerdfont#cellwidths#code_points = {
-      \ 'Codicons': [[0xea60, 0xebeb]],
-      \ 'Devicons': [[0xe700, 0xe7c5]],
-      \ 'Font Awesome': [[0xf000, 0xf2e0]],
-      \ 'Font Awesome Extension': [[0xe200, 0xe2a9]],
-      \ 'Font Logos': [[0xf300, 0xf372]],
-      \ 'IEC Power Symbols': [[0x23fb, 0x23fe], 0x2b58],
-      \ 'Material Design': [[0xf0001, 0xf1af0], [0xf500, 0xfd46]],
-      \ 'Octicons': [0x2665, 0x26a1, [0xf400, 0xf532]],
-      \ 'Pomicons': [[0xe000, 0xe00a]],
-      \ 'Powerline': [[0xe0a0, 0xe0a2], [0xe0b0, 0xe0b3]],
-      \ 'Powerline Extra': [0xe0a3, [0xe0b4, 0xe0c8], 0xe0ca, [0xe0cc, 0xe0d4]],
-      \ 'Seti-UI + Custom': [[0xe5fa, 0xe6b1]],
-      \ 'Weather Icons': [[0xe300, 0xe3e3]],
-      \}
-
-function! nerdfont#cellwidths#fix() abort
-  let l:values = reduce(values(g:nerdfont#cellwidths#code_points), { a, v -> a + v })
-  let l:values = map(l:values, {_, v -> type(v) is# v:t_list ? v : [v, v]})
+function! nerdfont#cellwidths#fix(code_points) abort
+  let l:values = map(a:code_points, {_, v -> type(v) is# v:t_list ? v : [v, v]})
   let l:list = map(l:values, {_, v -> type(v) is# v:t_list ? v + [2] : [v, v, 2]})
   let l:list = s:norm(l:list + getcellwidths())
   call setcellwidths(l:list)


### PR DESCRIPTION
Close #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an autofix feature to correct cell widths of nerd font glyphs automatically.

- **Bug Fixes**
  - Modified the glyph width fixing function to accept a parameter, enhancing its flexibility and reliability.

- **Refactor**
  - Adjusted functions to improve the logic flow and maintainability of the code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->