### PR TITLE
Revert "Avoid circular dependency in nerdfont#find"

### DIFF
--- a/autoload/nerdfont.vim
+++ b/autoload/nerdfont.vim
@@ -33,9 +33,7 @@ function! nerdfont#find(...) abort
     return glyph
   endif
 
-  return exists('g:nerdfont#default')
-        \ ? g:nerdfont#default
-        \ : nerdfont#path#extension#defaults['.']
+  return g:nerdfont#default
 endfunction
 
 function! s:autofix(result) abort
@@ -53,3 +51,7 @@ function! s:autofix(result) abort
     endtry
   endif
 endfunction
+
+let g:nerdfont#default = get(g:, 'nerdfont#default',
+      \ g:nerdfont#path#extension#defaults['.'])
+


### PR DESCRIPTION
This reverts commit 0b21e3f9b0926281a49a7ed8de12599dada90510.

It breaks thirdparty plugins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified handling of the default Nerd Font variable for improved performance.
	- Initialization of the default variable now occurs globally for better management.

- **Bug Fixes**
	- Enhanced reliability of the `nerdfont#find` function by removing unnecessary conditional checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->