### PR TITLE
Add g:loaded_nerdfont, play nice with other plugins

### DIFF
--- a/plugin/nerdfont.vim
+++ b/plugin/nerdfont.vim
@@ -1,0 +1,5 @@
+" Allow easy detection of nerdfont plugin loaded
+if exists("g:loaded_nerdfont")
+  finish
+endif
+let g:loaded_nerdfont = 1


### PR DESCRIPTION
Allow other plugins or conditional code in vimrc detect that vim-nerdfont is available without having to check &rtp etc.

Useful for plugins that automatically use vim-devicons to optionally use vim-nerdfont if installed, e.g. https://github.com/Donaldttt/fuzzyy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Nerd Font plugin to load only once, preventing redundant initialization and ensuring efficient performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->