### PR TITLE
Tighten vimrc regex

### DIFF
--- a/assets/json/pattern.json
+++ b/assets/json/pattern.json
@@ -7,7 +7,7 @@
   ".*materialize.*\\.js$": "",
   ".*mootools.*\\.js$": "",
   ".*require.*\\.js$": "",
-  ".*vimrc[^/\\\\]*$": "",
+  ".*vimrc[^/]*$": "",
   "/Contacts\\.$": "󰉌",
   "/Desktop\\.$": "",
   "/Downloads\\.$": "󰉍",

--- a/assets/json/pattern.json
+++ b/assets/json/pattern.json
@@ -7,7 +7,7 @@
   ".*materialize.*\\.js$": "",
   ".*mootools.*\\.js$": "",
   ".*require.*\\.js$": "",
-  ".*vimrc.*": "",
+  ".*vimrc[^/\\\\]*$": "",
   "/Contacts\\.$": "󰉌",
   "/Desktop\\.$": "",
   "/Downloads\\.$": "󰉍",

--- a/test/nerdfont/path/pattern.vimspec
+++ b/test/nerdfont/path/pattern.vimspec
@@ -15,6 +15,23 @@ Describe nerdfont#path#pattern
       Assert Equals(glyph, '')
     End
 
+    It returns a Vagrant glyph for 'Vagrantfile' stored under a vimrc path
+      let glyph = nerdfont#path#pattern#find('vimrc-modules/Vagrantfile')
+      Assert Equals(glyph, '')
+    End
+
+    It returns a Vagrant glyph for 'Vagrantfile' stored under a Windows vimrc path
+      let glyph = nerdfont#path#pattern#find('vimrc-modules\Vagrantfile')
+      Assert Equals(glyph, '')
+    End
+
+    It returns a Vim glyph for vimrc patterns
+      let glyph = nerdfont#path#pattern#find('vimrc-whatever')
+      Assert Equals(glyph, '')
+      let glyph = nerdfont#path#pattern#find('.vimrc')
+      Assert Equals(glyph, '')
+    End
+
     It returns an empty string for 'hogehogefoobar'
       let glyph = nerdfont#path#pattern#find('hogehogefoobar')
       Assert Equals(glyph, '')

--- a/test/nerdfont/path/pattern.vimspec
+++ b/test/nerdfont/path/pattern.vimspec
@@ -20,11 +20,6 @@ Describe nerdfont#path#pattern
       Assert Equals(glyph, '')
     End
 
-    It returns a Vagrant glyph for 'Vagrantfile' stored under a Windows vimrc path
-      let glyph = nerdfont#path#pattern#find('vimrc-modules\Vagrantfile')
-      Assert Equals(glyph, '')
-    End
-
     It returns a Vim glyph for vimrc patterns
       let glyph = nerdfont#path#pattern#find('vimrc-whatever')
       Assert Equals(glyph, '')


### PR DESCRIPTION
Closes #40 - I wish I had seen this issue three months ago, but managed to miss it (thanks for notifying me about everything except the things I'm interested in, GitHub), so here I am three months late

The solution here is just to slap a negative search for paths at it rather than using a `.*`. ~~I did include backslashes in the group, but noticed later that none of the other paths include backslashes. If the paths are indeed normalised to forward slashes, let me know and I'll drop those from the regex~~ Dropped per review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Refined detection of vimrc files to match only the filename at the current directory level, avoiding false positives in nested paths. Icon for vimrc remains unchanged.
  - Ensures .vimrc and vimrc-* files are correctly recognized across platforms.

- Tests
  - Added coverage for vimrc pattern matching on various Unix/Windows paths, including cases with vimrc-related directories and Vagrantfile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->