### PR TITLE
Add QNX to platform list

### DIFF
--- a/assets/json/platform.json
+++ b/assets/json/platform.json
@@ -24,6 +24,7 @@
   "mint": "",
   "nixos": "",
   "opensuse": "",
+  "qnx": "",
   "raspbian": "",
   "rhel": "",
   "rocky": "",

--- a/autoload/nerdfont/platform.vim
+++ b/autoload/nerdfont/platform.vim
@@ -29,6 +29,10 @@ function! s:find_platform() abort
     let s:platform = 'freebsd'
     return s:platform
   endif
+  if has('qnx')
+    let s:platform = 'qnx'
+    return s:platform
+  endif
   " https://github.com/tox-dev/platformdirs/blob/4.5.0/src/platformdirs/__init__.py#L31
   if $ANDROID_DATA ==# '/data' && $ANDROID_ROOT ==# '/system'
     let s:platform = 'android'


### PR DESCRIPTION
Without this an error message is printed on QNX?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for QNX platform detection, improving compatibility for users on QNX systems.
  * Platform listings updated to include QNX so the UI and tooling reflect that platform.
  * Detection now recognizes QNX earlier in the sequence for more reliable identification; no other user settings changed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lambdalisue/vim-nerdfont/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->