### PR TITLE
Add email/mailbox icons for mutt/neomutt

### DIFF
--- a/assets/json/basename.json
+++ b/assets/json/basename.json
@@ -199,6 +199,8 @@
   "manifest.in": "",
   "mix.lock": "",
   "mpv.conf": "",
+  "muttrc": "󰛮",
+  "neomuttrc": "󰛮",
   "npm-shrinkwrap.json": "",
   "npmignore": "",
   "npmrc": "",

--- a/assets/json/pattern.json
+++ b/assets/json/pattern.json
@@ -56,6 +56,10 @@
   "/lib32.$": "",
   "/lib64.$": "",
   "/libexec.$": "",
+  "/mutt.$": "󰛮",
+  "/muttrc": "󰛮",
+  "/neomutt.$": "󰛮",
+  "/neomuttrc": "󰛮",
   "/node_modules.$": "",
   "/node_modules\\.$": "",
   "/npm_cache\\.$": "",
@@ -68,5 +72,7 @@
   "/xbps\\.d.$": "",
   "/xorg\\.conf.d.$": "",
   "Vagrantfile$": "",
-  "^zhihu://": ""
+  "^zhihu://": "",
+  "mutt-": "󰻣",
+  "neomutt-": "󰻣"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added icon support for additional mail client configuration filenames, including `muttrc` and `neomuttrc`.
  * Expanded pattern-based matching to recognize more related mutt/neomutt config and prefixed URL/file patterns, improving icon detection accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->